### PR TITLE
Added example for setting up the client

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,22 @@ Or install it yourself as:
 Read their [API documentation](http://www.activecampaign.com/api/overview.php)for how to use this gem.
 
 ```ruby
+# To setup the client
+client = ::ActiveCampaign::Client.new(
+        api_endpoint: 'YOUR-ENDPOINT', # e.g. 'https://yourendpoint.api-us1.com'
+        api_key: 'YOUR-API-KEY') # e.g. 'a4e60a1ba200595d5cc37ede5732545184165e'
+```
+
+```ruby
 # To fetch all lists
-ActiveCampaign.list_list ids: 'all'
+client.list_list ids: 'all'
 ```
 
 ```ruby
 # To sync a contact (create if doesn't exist or update if matching email)
 # you have to resort to some really ugly hacks. Due to the form serialization # type of API (read not a object oriented REST API) you need to translate
 # something pretty into something horrific when it comes to the parameters.
-ActiveCampaign.contact_sync({
+client.contact_sync({
                                      "id" => user.active_campaign_contact_id,
                                   "email" => user.email,
                              "first_name" => user.first,
@@ -54,7 +61,7 @@ status_params = {
              "#{user.other_list_id}" => true ? 1 : 2,
 }
 
-ActiveCampaign.contact_sync({
+client.contact_sync({
         "id" => user.active_campaign_contact_id,
      "email" => user.email,
 "first_name" => user.first,
@@ -67,7 +74,7 @@ ActiveCampaign.contact_sync({
 ## Response
 
 All responses are wrapped under `results` so
-`ActiveCampaign.list_list ids: 'all'` returns
+`client.list_list ids: 'all'` returns
 
 ```ruby
 {


### PR DESCRIPTION
The original README didn't include an example that explained how to connect to setup the client to connect to ActiveCampaign. I've added this definition, and updated the examples to use the `client`.